### PR TITLE
Removed old ajax options and updated new ajax option.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,8 +14,7 @@ var Atatus = module.exports = integration('Atatus')
   .global('atatus')
   .option('apiKey', '')
   .option('enableSourcemap', false)
-  .option('enableAjaxAbort', false)
-  .option('enableAjaxErrors', false)
+  .option('disableAjaxMonitoring', false)
   .tag('<script src="//dmc1acwvwny3.cloudfront.net/atatus.js">');
 
 /**
@@ -32,8 +31,7 @@ Atatus.prototype.initialize = function() {
   this.load(function() {
     var configOptions = {
       enableSourcemap: self.options.enableSourcemap,
-      enableAjaxAbort: self.options.enableAjaxAbort,
-      enableAjaxErrors: self.options.enableAjaxErrors
+      disableAjaxMonitoring: self.options.disableAjaxMonitoring
     };
 
     // Configure Atatus and install default handler to capture uncaught

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -33,8 +33,7 @@ describe('Atatus', function() {
       .global('atatus')
       .option('apiKey', '')
       .option('enableSourcemap', false)
-      .option('enableAjaxAbort', false)
-      .option('enableAjaxErrors', false));
+      .option('disableAjaxMonitoring', false));
   });
 
   describe('before loading', function() {


### PR DESCRIPTION
Previously i did some mistake in rebase. so i delete that repo and created new repo with clean commits. 

We have removed two old options from our script.
- enableAjaxErrors
- enableAjaxAbort

Can you  also remove these options from Segment Atatus integration page?

Please add an option `disableAjaxMonitoring` in the integration page.

**Title:** Disable AJAX Monitoring
**Description:** If you don't want to track the AJAX(XHR) requests in your app, then select this option.
