### PR TITLE
Added allowed domains and enable offilne options.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,6 @@ var is = require('is');
 var Atatus = module.exports = integration('Atatus')
   .global('atatus')
   .option('apiKey', '')
-  .option('enableSourcemap', false)
   .option('disableAjaxMonitoring', false)
   .option('allowedDomains', '')
   .option('enableOffline', false)
@@ -32,7 +31,6 @@ Atatus.prototype.initialize = function() {
 
   this.load(function() {
     var configOptions = {
-      enableSourcemap: self.options.enableSourcemap,
       disableAjaxMonitoring: self.options.disableAjaxMonitoring
     };
 
@@ -70,8 +68,13 @@ Atatus.prototype.loaded = function() {
 
 Atatus.prototype.identify = function(identify) {
   var uid = identify.userId();
+  var traits = identify.traits() || {};
+  var email = traits.email;
+  var name = traits.name;
+
   if (uid) {
-    window.atatus.setUser(uid);
+    window.atatus.setUser(uid, email, name);
   }
-  window.atatus.setCustomData({ person: identify.traits() });
+
+  window.atatus.setCustomData(traits);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,8 @@ var Atatus = module.exports = integration('Atatus')
   .option('apiKey', '')
   .option('enableSourcemap', false)
   .option('disableAjaxMonitoring', false)
+  .option('allowedDomains', '')
+  .option('enableOffline', false)
   .tag('<script src="//dmc1acwvwny3.cloudfront.net/atatus.js">');
 
 /**
@@ -37,6 +39,13 @@ Atatus.prototype.initialize = function() {
     // Configure Atatus and install default handler to capture uncaught
     // exceptions
     window.atatus.config(self.options.apiKey, configOptions).install();
+
+    // Set allowed domains and enable offline
+    if (self.options.allowedDomains) {
+      window.atatus.setAllowedDomains(self.options.allowedDomains.split(','));
+    }
+    window.atatus.enableOffline(!!self.options.enableOffline);
+
     self.ready();
   });
 };
@@ -60,5 +69,9 @@ Atatus.prototype.loaded = function() {
  */
 
 Atatus.prototype.identify = function(identify) {
+  var uid = identify.userId();
+  if (uid) {
+    window.atatus.setUser(uid);
+  }
   window.atatus.setCustomData({ person: identify.traits() });
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -32,7 +32,6 @@ describe('Atatus', function() {
     analytics.compare(Atatus, integration('Atatus')
       .global('atatus')
       .option('apiKey', '')
-      .option('enableSourcemap', false)
       .option('disableAjaxMonitoring', false)
       .option('allowedDomains', '')
       .option('enableOffline', false));
@@ -80,19 +79,19 @@ describe('Atatus', function() {
       it('should send an id', function() {
         analytics.identify('id');
         analytics.called(window.atatus.setUser, 'id');
-        analytics.called(window.atatus.setCustomData, { person: { id: 'id' } });
+        analytics.called(window.atatus.setCustomData, { id: 'id' });
       });
 
       it('should send only traits', function() {
         analytics.identify({ trait: true });
         analytics.didNotCall(window.atatus.setUser);
-        analytics.called(window.atatus.setCustomData, { person: { trait: true } });
+        analytics.called(window.atatus.setCustomData, { trait: true });
       });
 
       it('should send an id and traits', function() {
-        analytics.identify('id', { trait: true });
-        analytics.called(window.atatus.setUser, 'id');
-        analytics.called(window.atatus.setCustomData, { person: { id: 'id', trait: true } });
+        analytics.identify('id', { name: 'John Doe', email: 'john@acme.com' });
+        analytics.called(window.atatus.setUser, 'id', 'john@acme.com', 'John Doe');
+        analytics.called(window.atatus.setCustomData, { id: 'id', name: 'John Doe', email: 'john@acme.com' });
       });
     });
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -33,7 +33,9 @@ describe('Atatus', function() {
       .global('atatus')
       .option('apiKey', '')
       .option('enableSourcemap', false)
-      .option('disableAjaxMonitoring', false));
+      .option('disableAjaxMonitoring', false)
+      .option('allowedDomains', '')
+      .option('enableOffline', false));
   });
 
   describe('before loading', function() {
@@ -77,16 +79,19 @@ describe('Atatus', function() {
 
       it('should send an id', function() {
         analytics.identify('id');
+        analytics.called(window.atatus.setUser, 'id');
         analytics.called(window.atatus.setCustomData, { person: { id: 'id' } });
       });
 
-      it('should send traits', function() {
+      it('should send only traits', function() {
         analytics.identify({ trait: true });
+        analytics.didNotCall(window.atatus.setUser);
         analytics.called(window.atatus.setCustomData, { person: { trait: true } });
       });
 
       it('should send an id and traits', function() {
         analytics.identify('id', { trait: true });
+        analytics.called(window.atatus.setUser, 'id');
         analytics.called(window.atatus.setCustomData, { person: { id: 'id', trait: true } });
       });
     });


### PR DESCRIPTION
1. Support for user id, email and name in identify.
2. Please add two new options in the segment UI.

-  New option `enableOffline`

```
Label: Enable Offline
Description: Enable offline errors and metrics tracking when network connectivity is not available
```
- New option `allowedDomains`

```
Label:  Allowed Domains (Comma Separated)
Description:  Track errors and performance metrics only from specific domains.
```

3. Please remove the option `Enable Source Map`