### PR TITLE
Added SPA support by default and option to disable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,24 +15,27 @@ var Atatus = module.exports = integration('Atatus')
   .global('atatus')
   .option('apiKey', '')
   .option('disableAjaxMonitoring', false)
+  .option('disableSPA', false)
   .option('allowedDomains', [])
   .option('enableOffline', false)
-  .tag('<script src="//dmc1acwvwny3.cloudfront.net/atatus.js">');
+  .tag('<script src="//dmc1acwvwny3.cloudfront.net/{{ lib }}.js">');
 
 /**
  * Initialize.
  *
- * https://www.atatus.com/docs.html
+ * https://docs.atatus.com/docs/browser-monitoring/customize-agent.html
  *
  * @api public
  */
 
 Atatus.prototype.initialize = function() {
+  var lib = this.options.disableSPA ? 'atatus' : 'atatus-spa';
   var self = this;
 
-  this.load(function() {
+  this.load({ lib: lib }, function() {
     var configOptions = {
-      disableAjaxMonitoring: self.options.disableAjaxMonitoring
+      disableAjaxMonitoring: self.options.disableAjaxMonitoring,
+      disableSPA: self.options.disableSPA
     };
 
     // Configure Atatus and install default handler to capture uncaught

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -34,6 +34,7 @@ describe('Atatus', function() {
       .global('atatus')
       .option('apiKey', '')
       .option('disableAjaxMonitoring', false)
+      .option('disableSPA', false)
       .option('allowedDomains', [])
       .option('enableOffline', false));
   });
@@ -53,6 +54,25 @@ describe('Atatus', function() {
   });
 
   describe('loading', function() {
+    beforeEach(function() {
+      analytics.spy(atatus, 'load');
+    });
+
+    it('should load spa version by default', function(done) {
+      analytics.load(atatus, function() {
+        analytics.assert(window.atatus.spa);
+        done();
+      });
+    });
+
+    it('should load non-spa version if you have set `disableSPA` to true', function(done) {
+      atatus.options.disableSPA = true;
+      analytics.load(atatus, function() {
+        analytics.assert(!window.atatus.spa);
+        done();
+      });
+    });
+
     it('should load and set an onerror handler', function(done) {
       analytics.load(atatus, function(err) {
         if (err) return done(err);


### PR DESCRIPTION
We have added new feature Single Page App(SPA) monitoring to our product. We updated segment integration to load SPA script by default. Also we added new option `disableSPA` to disable this feature.

Can you please merge it?

And add an option disableSPA with following name in the Atatus integration page.

     Disable tracking of SPA routes.

The description of this option:

     If you don't want to monitor single page application route changes, enable this setting.